### PR TITLE
added utf-8 encoding to dumping of results

### DIFF
--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -287,7 +287,7 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
         batch_sizes = ",".join(map(str, results["config"]["batch_sizes"]))
 
         if args.output_path:
-            output_path_file.open("w").write(dumped)
+            output_path_file.open("w", encoding="utf-8").write(dumped)
 
             if args.log_samples:
                 for task_name, config in results["configs"].items():


### PR DESCRIPTION
Hello!

I tried running the eval harness, but got an encoding error during the dumping of the results (had to run the whole evaluation harness again because of this).

I added `encoding="utf-8"` in the `__main__.py` (line 290) at the `lm_eval` folder to avoid this kind of thing happening again.

Before, it was:

```python
if args.output_path:
            output_path_file.open("w").write(dumped)
```
Now is:

```python
if args.output_path:
            output_path_file.open("w", encoding="utf-8").write(dumped)
```

And that is it.

Congratulations on putting this harness together, will be definitely using in the future.

